### PR TITLE
fix(ios): remove unnecessary canPlayFastForward / canPlaySlowForward checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.3
+
+- Removed `canPlayFastForward` and `canPlaySlowForward` checks on iOS `setSpeed`
+  - These properties incorrectly return `NO` for many valid HLS streams, causing `unsupported_fast_forward` / `unsupported_slow_forward` errors even when playback speed works fine in Safari and other players
+  - `AVPlayer` natively handles unsupported rates gracefully, so explicit checks are unnecessary
+
 ## 1.0.2
 
 - Fixed playedPart NAN on material progressbar [by [elKood Solutions](https://github.com/ElKood-Sol)]

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -551,20 +551,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         result([FlutterError errorWithCode:@"unsupported_speed"
                                    message:@"Speed must be >= 0.0 and <= 2.0"
                                    details:nil]);
-    } else if ((speed > 1.0 && _player.currentItem.canPlayFastForward) ||
-               (speed < 1.0 && _player.currentItem.canPlaySlowForward)) {
+    } else {
         _playerRate = speed;
         result(nil);
-    } else {
-        if (speed > 1.0) {
-            result([FlutterError errorWithCode:@"unsupported_fast_forward"
-                                       message:@"This video cannot be played fast forward"
-                                       details:nil]);
-        } else {
-            result([FlutterError errorWithCode:@"unsupported_slow_forward"
-                                       message:@"This video cannot be played slow forward"
-                                       details:nil]);
-        }
     }
 
     if (_isPlaying){

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_player_enhanced
 description: Advanced video player based on video_player and Chewie. Supports HLS, DASH, DRM, cache, subtitles, PiP, and much more. AndroidX Media3 powered.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/kingace2056/betterplayer
 documentation: https://jhomlala.github.io/betterplayer/
 


### PR DESCRIPTION
## Problem
On iOS, calling `setSpeed` with values other than `1.0` on many HLS streams throws a `PlatformException` with code `unsupported_fast_forward` or `unsupported_slow_forward`, even though the same stream plays perfectly fine at increased speed in Safari and other players.

## Root Cause
The iOS implementation checks `AVPlayerItem.canPlayFastForward` and `canPlaySlowForward` before applying the playback rate. These properties are known to incorrectly return `NO` for valid streams (especially HLS), causing the plugin to reject speed changes that the underlying `AVPlayer` is perfectly capable of handling.

## Solution
Removes the `canPlayFastForward` and `canPlaySlowForward` gate checks from `BetterPlayer.m`. The `AVPlayer` natively handles unsupported rates gracefully — it either applies the rate or falls back to `1.0` without crashing or throwing.

## References
- **Safari**: plays the same HLS stream at 2x without any issue, confirming the stream supports fast forward
- **video_player (official Flutter plugin)**: applies `_player.rate = speed` directly. It uses `canPlayFastForward`/`canPlaySlowForward` only for *clamping* (limiting to 2.0/1.0), never for throwing errors ([source](https://github.com/flutter/packages/blob/main/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m))

## Changes
- `ios/Classes/BetterPlayer.m`: removed conditional checks, now directly applies the rate within the valid `0.0`–`2.0` range