### PR TITLE
Guard video player lifecycle and absolute positions

### DIFF
--- a/android/src/main/kotlin/com/sarthak/better_player_enhanced/BetterPlayer.kt
+++ b/android/src/main/kotlin/com/sarthak/better_player_enhanced/BetterPlayer.kt
@@ -499,7 +499,16 @@ internal class BetterPlayer(
                     val windowStartTimeMs =
                         timeline.getWindow(0, Timeline.Window()).windowStartTimeMs
                     val pos = exoPlayer?.currentPosition ?: 0L
-                    return windowStartTimeMs + pos
+                    if (windowStartTimeMs == C.TIME_UNSET) return 0L
+
+                    val absolutePositionMs = windowStartTimeMs + pos
+                    if (absolutePositionMs <= 0L ||
+                        absolutePositionMs > 8640000000000000L
+                    ) {
+                        return 0L
+                    }
+
+                    return absolutePositionMs
                 }
             }
             return exoPlayer?.currentPosition ?: 0L

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -341,13 +341,34 @@ bool _remoteCommandsInitialized = false;
             } else if (uriArg) {
                 [player setDataSourceURL:[NSURL URLWithString:uriArg] withKey:key withCertificateUrl:certificateUrl withLicenseUrl: licenseUrl withHeaders:headers withCache: useCache cacheKey:cacheKey cacheManager:_cacheManager overriddenDuration:overriddenDuration videoExtension: videoExtension];
                 AVPlayerItem *currentItem = player.player.currentItem;
-                    if (currentItem) {
-                        AVAsset *asset = currentItem.asset;
-                        AVMediaSelectionGroup *group = [asset mediaSelectionGroupForMediaCharacteristic:AVMediaCharacteristicLegible];
-                        if (group) {
-                            [currentItem selectMediaOption:nil inMediaSelectionGroup:group];
+                if (currentItem) {
+                    AVAsset *asset = currentItem.asset;
+                    NSString *key = @"availableMediaCharacteristicsWithMediaSelectionOptions";
+                    __weak BetterPlayer *weakPlayer = player;
+                    __weak AVPlayerItem *weakItem = currentItem;
+                    // Do not query media selection synchronously here. Remote HLS
+                    // assets can load subtitle metadata over the network and block
+                    // the platform thread long enough for iOS AppHang reports.
+                    [asset loadValuesAsynchronouslyForKeys:@[key] completionHandler:^{
+                        NSError *error = nil;
+                        if ([asset statusOfValueForKey:key error:&error] != AVKeyValueStatusLoaded) {
+                            return;
                         }
-                    }
+
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            BetterPlayer *strongPlayer = weakPlayer;
+                            AVPlayerItem *strongItem = weakItem;
+                            if (!strongPlayer || !strongItem || strongPlayer.disposed || strongPlayer.player.currentItem != strongItem) {
+                                return;
+                            }
+
+                            AVMediaSelectionGroup *group = [asset mediaSelectionGroupForMediaCharacteristic:AVMediaCharacteristicLegible];
+                            if (group) {
+                                [strongItem selectMediaOption:nil inMediaSelectionGroup:group];
+                            }
+                        });
+                    }];
+                }
             } else {
                 result(FlutterMethodNotImplemented);
             }

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -9,6 +9,11 @@
 #error Code Requires ARC.
 #endif
 
+@interface BetterPlayerPlugin ()
+- (BetterPlayer*)activeNotificationPlayer;
+- (void)removeRemoteCommandTargets;
+@end
+
 
 @implementation BetterPlayerPlugin
 NSMutableDictionary* _dataSourceDict;
@@ -18,6 +23,10 @@ CacheManager* _cacheManager;
 int texturesCount = -1;
 BetterPlayer* _notificationPlayer;
 bool _remoteCommandsInitialized = false;
+id _togglePlayPauseCommandTarget;
+id _playCommandTarget;
+id _pauseCommandTarget;
+id _changePlaybackPositionCommandTarget;
 
 
 #pragma mark - FlutterPlugin protocol
@@ -46,6 +55,8 @@ bool _remoteCommandsInitialized = false;
 }
 
 - (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    [self removeRemoteCommandTargets];
+    _notificationPlayer = nil;
     for (NSNumber* textureId in _players.allKeys) {
         BetterPlayer* player = _players[textureId];
         [player disposeSansEventChannel];
@@ -124,6 +135,7 @@ bool _remoteCommandsInitialized = false;
     if (_remoteCommandsInitialized){
         return;
     }
+    [self removeRemoteCommandTargets];
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
     [commandCenter.togglePlayPauseCommand setEnabled:YES];
     [commandCenter.playCommand setEnabled:YES];
@@ -134,46 +146,94 @@ bool _remoteCommandsInitialized = false;
         [commandCenter.changePlaybackPositionCommand setEnabled:YES];
     }
 
-    [commandCenter.togglePlayPauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        if (_notificationPlayer != [NSNull null]){
-            if (_notificationPlayer.isPlaying){
-                _notificationPlayer.eventSink(@{@"event" : @"play"});
-            } else {
-                _notificationPlayer.eventSink(@{@"event" : @"pause"});
-            }
+    __weak typeof(self) weakSelf = self;
+    _togglePlayPauseCommandTarget = [commandCenter.togglePlayPauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        BetterPlayer* notificationPlayer = [strongSelf activeNotificationPlayer];
+        if (!notificationPlayer) {
+            return MPRemoteCommandHandlerStatusCommandFailed;
+        }
+        if (notificationPlayer.isPlaying){
+            notificationPlayer.eventSink(@{@"event" : @"play"});
+        } else {
+            notificationPlayer.eventSink(@{@"event" : @"pause"});
         }
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
-    [commandCenter.playCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        if (_notificationPlayer != [NSNull null]){
-            _notificationPlayer.eventSink(@{@"event" : @"play"});
+    _playCommandTarget = [commandCenter.playCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        BetterPlayer* notificationPlayer = [strongSelf activeNotificationPlayer];
+        if (!notificationPlayer) {
+            return MPRemoteCommandHandlerStatusCommandFailed;
         }
+        notificationPlayer.eventSink(@{@"event" : @"play"});
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
-    [commandCenter.pauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        if (_notificationPlayer != [NSNull null]){
-            _notificationPlayer.eventSink(@{@"event" : @"pause"});
+    _pauseCommandTarget = [commandCenter.pauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        BetterPlayer* notificationPlayer = [strongSelf activeNotificationPlayer];
+        if (!notificationPlayer) {
+            return MPRemoteCommandHandlerStatusCommandFailed;
         }
+        notificationPlayer.eventSink(@{@"event" : @"pause"});
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
 
 
     if (@available(iOS 9.1, *)) {
-        [commandCenter.changePlaybackPositionCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-            if (_notificationPlayer != [NSNull null]){
-                MPChangePlaybackPositionCommandEvent * playbackEvent = (MPChangePlaybackRateCommandEvent * ) event;
-                CMTime time = CMTimeMake(playbackEvent.positionTime, 1);
-                int64_t millis = [BetterPlayerTimeUtils FLTCMTimeToMillis:(time)];
-                [_notificationPlayer seekTo: millis];
-                _notificationPlayer.eventSink(@{@"event" : @"seek", @"position": @(millis)});
+        _changePlaybackPositionCommandTarget = [commandCenter.changePlaybackPositionCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            BetterPlayer* notificationPlayer = [strongSelf activeNotificationPlayer];
+            if (!notificationPlayer) {
+                return MPRemoteCommandHandlerStatusCommandFailed;
             }
+            MPChangePlaybackPositionCommandEvent * playbackEvent = (MPChangePlaybackPositionCommandEvent *) event;
+            CMTime time = CMTimeMake(playbackEvent.positionTime, 1);
+            int64_t millis = [BetterPlayerTimeUtils FLTCMTimeToMillis:(time)];
+            [notificationPlayer seekTo: millis];
+            notificationPlayer.eventSink(@{@"event" : @"seek", @"position": @(millis)});
             return MPRemoteCommandHandlerStatusSuccess;
         }];
     }
     _remoteCommandsInitialized = true;
+}
+
+- (BetterPlayer*)activeNotificationPlayer {
+    if (!_notificationPlayer || (id)_notificationPlayer == [NSNull null]) {
+        return nil;
+    }
+    if (_notificationPlayer.disposed || !_notificationPlayer.eventSink) {
+        return nil;
+    }
+    return _notificationPlayer;
+}
+
+- (void)removeRemoteCommandTargets {
+    MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+    if (_togglePlayPauseCommandTarget) {
+        [commandCenter.togglePlayPauseCommand removeTarget:_togglePlayPauseCommandTarget];
+        _togglePlayPauseCommandTarget = nil;
+    }
+    if (_playCommandTarget) {
+        [commandCenter.playCommand removeTarget:_playCommandTarget];
+        _playCommandTarget = nil;
+    }
+    if (_pauseCommandTarget) {
+        [commandCenter.pauseCommand removeTarget:_pauseCommandTarget];
+        _pauseCommandTarget = nil;
+    }
+    if (@available(iOS 9.1, *)) {
+        if (_changePlaybackPositionCommandTarget) {
+            [commandCenter.changePlaybackPositionCommand removeTarget:_changePlaybackPositionCommandTarget];
+            _changePlaybackPositionCommandTarget = nil;
+        }
+    } else {
+        _changePlaybackPositionCommandTarget = nil;
+    }
+    _remoteCommandsInitialized = false;
 }
 
 - (void) setupRemoteCommandNotification:(BetterPlayer*)player, NSString* title, NSString* author , NSString* imageUrl{
@@ -247,8 +307,8 @@ bool _remoteCommandsInitialized = false;
 
 - (void) disposeNotificationData: (BetterPlayer*)player{
     if (player == _notificationPlayer){
-        _notificationPlayer = NULL;
-        _remoteCommandsInitialized = false;
+        [self removeRemoteCommandTargets];
+        _notificationPlayer = nil;
     }
     NSString* key =  [self getTextureId:player];
     id _timeObserverId = _timeObserverIdDict[key];
@@ -282,6 +342,8 @@ bool _remoteCommandsInitialized = false;
 
     if ([@"init" isEqualToString:call.method]) {
         // Allow audio playback when the Ring/Silent switch is set to silent
+        [self removeRemoteCommandTargets];
+        _notificationPlayer = nil;
         for (NSNumber* textureId in _players) {
             [_players[textureId] dispose];
         }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1283,7 +1283,6 @@ class BetterPlayerController {
     }
     if (!_disposed) {
       if (videoPlayerController != null) {
-        pause();
         videoPlayerController!.removeListener(_onFullScreenStateChanged);
         videoPlayerController!.removeListener(_onVideoPlayerChanged);
         videoPlayerController!.dispose();

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -217,7 +217,10 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
         ) ??
         0;
 
-    if (milliseconds <= 0) return null;
+    const int maxDateTimeMilliseconds = 8640000000000000;
+    if (milliseconds <= 0 || milliseconds > maxDateTimeMilliseconds) {
+      return null;
+    }
 
     return DateTime.fromMillisecondsSinceEpoch(milliseconds);
   }

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -213,10 +213,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// Attempts to open the given [dataSource] and load metadata about the video.
   Future<void> _create() async {
-    _textureId = await _videoPlayerPlatform.create(
-      bufferingConfiguration: bufferingConfiguration,
-    );
-    _creatingCompleter.complete(null);
+    try {
+      _textureId = await _videoPlayerPlatform.create(
+        bufferingConfiguration: bufferingConfiguration,
+      );
+      _creatingCompleter.complete(null);
+    } catch (error, stackTrace) {
+      if (!_creatingCompleter.isCompleted) {
+        _creatingCompleter.completeError(error, stackTrace);
+      }
+      return;
+    }
 
     if (_isDisposed) {
       return;
@@ -438,7 +445,15 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     value = VideoPlayerValue.uninitialized();
     _cancelPositionTimer();
 
-    await _creatingCompleter.future;
+    try {
+      await _creatingCompleter.future;
+    } catch (_) {
+      await _eventSubscription?.cancel();
+      _eventSubscription = null;
+      await videoEventStreamController.close();
+      super.dispose();
+      return;
+    }
 
     await _eventSubscription?.cancel();
     _eventSubscription = null;

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -190,8 +190,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   StreamSubscription<dynamic>? _eventSubscription;
 
   bool get _created => _creatingCompleter.isCompleted;
-  bool get _hasPlatformPlayer =>
-      _created && !_isDisposed && _textureId != null;
+  bool get _hasPlatformPlayer => _created && !_isDisposed && _textureId != null;
   Duration? _seekPosition;
 
   void _cancelPositionTimer([Timer? timer]) {
@@ -589,6 +588,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         return null;
       }
       rethrow;
+    } on ArgumentError {
+      return null;
     }
   }
 

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -190,7 +190,21 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   StreamSubscription<dynamic>? _eventSubscription;
 
   bool get _created => _creatingCompleter.isCompleted;
+  bool get _hasPlatformPlayer =>
+      _created && !_isDisposed && _textureId != null;
   Duration? _seekPosition;
+
+  void _cancelPositionTimer([Timer? timer]) {
+    timer?.cancel();
+    if (timer == null || identical(_timer, timer)) {
+      _timer = null;
+    }
+  }
+
+  bool _isTeardownPlatformException(PlatformException exception) {
+    return exception.code == 'Unknown textureId' ||
+        exception.code == 'no_activity';
+  }
 
   /// This is just exposed for testing. It shouldn't be used by anyone depending
   /// on the plugin.
@@ -203,6 +217,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       bufferingConfiguration: bufferingConfiguration,
     );
     _creatingCompleter.complete(null);
+
+    if (_isDisposed) {
+      return;
+    }
 
     unawaited(_applyLooping());
     unawaited(_applyVolume());
@@ -412,16 +430,26 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   @override
   Future<void> dispose() async {
-    await _creatingCompleter.future;
-    if (!_isDisposed) {
-      _isDisposed = true;
-      value = VideoPlayerValue.uninitialized();
-      _timer?.cancel();
-      await _eventSubscription?.cancel();
-      await _videoPlayerPlatform.dispose(_textureId);
-      videoEventStreamController.close();
+    if (_isDisposed) {
+      return;
     }
+
     _isDisposed = true;
+    value = VideoPlayerValue.uninitialized();
+    _cancelPositionTimer();
+
+    await _creatingCompleter.future;
+
+    await _eventSubscription?.cancel();
+    _eventSubscription = null;
+
+    final textureId = _textureId;
+    _textureId = null;
+    if (textureId != null) {
+      await _videoPlayerPlatform.dispose(textureId);
+    }
+
+    await videoEventStreamController.close();
     super.dispose();
   }
 
@@ -456,26 +484,39 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   Future<void> _applyPlayPause() async {
-    if (!_created || _isDisposed) {
+    if (!_hasPlatformPlayer) {
       return;
     }
-    _timer?.cancel();
+    _cancelPositionTimer();
     if (value.isPlaying) {
       await _videoPlayerPlatform.play(_textureId);
+      if (!_hasPlatformPlayer || !value.isPlaying) {
+        return;
+      }
       _timer = Timer.periodic(
         const Duration(milliseconds: 300),
         (Timer timer) async {
-          if (_isDisposed) {
+          if (!_hasPlatformPlayer || !value.isPlaying) {
+            _cancelPositionTimer(timer);
             return;
           }
           final Duration? newPosition = await position;
+          if (newPosition == null) {
+            _cancelPositionTimer(timer);
+            return;
+          }
+          if (!_hasPlatformPlayer || !value.isPlaying) {
+            _cancelPositionTimer(timer);
+            return;
+          }
           final DateTime? newAbsolutePosition = await absolutePosition;
           // ignore: invariant_booleans
-          if (_isDisposed) {
+          if (!_hasPlatformPlayer || !value.isPlaying) {
+            _cancelPositionTimer(timer);
             return;
           }
           _updatePosition(newPosition, absolutePosition: newAbsolutePosition);
-          if (_seekPosition != null && newPosition != null) {
+          if (_seekPosition != null) {
             final difference =
                 newPosition.inMilliseconds - _seekPosition!.inMilliseconds;
             if (difference > 0) {
@@ -505,19 +546,35 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// The position in the current video.
   Future<Duration?> get position async {
-    if (!value.initialized && _isDisposed) {
+    if (!_hasPlatformPlayer) {
       return null;
     }
-    return _videoPlayerPlatform.getPosition(_textureId);
+    try {
+      return await _videoPlayerPlatform.getPosition(_textureId);
+    } on PlatformException catch (exception) {
+      if (!_hasPlatformPlayer || _isTeardownPlatformException(exception)) {
+        _cancelPositionTimer();
+        return null;
+      }
+      rethrow;
+    }
   }
 
   /// The absolute position in the current video stream
   /// (i.e. EXT-X-PROGRAM-DATE-TIME in HLS).
   Future<DateTime?> get absolutePosition async {
-    if (!value.initialized && _isDisposed) {
+    if (!_hasPlatformPlayer) {
       return null;
     }
-    return _videoPlayerPlatform.getAbsolutePosition(_textureId);
+    try {
+      return await _videoPlayerPlatform.getAbsolutePosition(_textureId);
+    } on PlatformException catch (exception) {
+      if (!_hasPlatformPlayer || _isTeardownPlatformException(exception)) {
+        _cancelPositionTimer();
+        return null;
+      }
+      rethrow;
+    }
   }
 
   /// Sets the video's current timestamp to be at [moment]. The next

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   visibility_detector: ^0.4.0+2
   path_provider: ^2.1.5
   collection: ^1.19.1
-  xml: ^6.6.1
+  xml: ^7.0.1
 
 dev_dependencies:
   lint: ^2.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   visibility_detector: ^0.4.0+2
   path_provider: ^2.1.5
   collection: ^1.19.1
-  xml: ^7.0.1
+  xml: '>=6.5.0 <8.0.0'
 
 dev_dependencies:
   lint: ^2.8.0

--- a/test/video_player_lifecycle_test.dart
+++ b/test/video_player_lifecycle_test.dart
@@ -1,0 +1,78 @@
+import 'package:better_player_enhanced/better_player.dart';
+import 'package:better_player_enhanced/src/video_player/video_player.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'mock_video_player_controller.dart';
+
+class _CountingVideoPlayerController extends MockVideoPlayerController {
+  int pauseCallCount = 0;
+  int disposeCallCount = 0;
+
+  @override
+  Future<void> pause() async {
+    pauseCallCount += 1;
+    return super.pause();
+  }
+
+  @override
+  // ignore: must_call_super
+  Future<void> dispose() async {
+    disposeCallCount += 1;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('better_player_channel');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('position polling stops after texture teardown error', () async {
+    var positionCalls = 0;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          switch (methodCall.method) {
+            case 'create':
+              return <String, dynamic>{'textureId': 1};
+            case 'play':
+              return null;
+            case 'position':
+              positionCalls += 1;
+              throw PlatformException(
+                code: 'Unknown textureId',
+                message: 'No video player associated with texture id 1',
+              );
+            default:
+              return null;
+          }
+        });
+
+    final controller = VideoPlayerController();
+    await Future<void>.delayed(Duration.zero);
+
+    await controller.play();
+    await Future<void>.delayed(const Duration(milliseconds: 750));
+
+    expect(positionCalls, 1);
+    await controller.dispose();
+  });
+
+  test('better player dispose does not send an extra pause command', () {
+    final controller = BetterPlayerController(
+      const BetterPlayerConfiguration(),
+    );
+    final videoController = _CountingVideoPlayerController();
+    controller.videoPlayerController = videoController;
+
+    controller.dispose();
+
+    expect(videoController.pauseCallCount, 0);
+    expect(videoController.disposeCallCount, 1);
+  });
+}

--- a/test/video_player_lifecycle_test.dart
+++ b/test/video_player_lifecycle_test.dart
@@ -63,6 +63,25 @@ void main() {
     await controller.dispose();
   });
 
+  test('dispose completes when platform player creation fails', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          if (methodCall.method == 'create') {
+            throw PlatformException(
+              code: 'create_failed',
+              message: 'Failed to create platform player',
+            );
+          }
+          return null;
+        });
+
+    final controller = VideoPlayerController();
+    await expectLater(
+      controller.dispose().timeout(const Duration(seconds: 1)),
+      completes,
+    );
+  });
+
   test('better player dispose does not send an extra pause command', () {
     final controller = BetterPlayerController(
       const BetterPlayerConfiguration(),

--- a/test/video_player_lifecycle_test.dart
+++ b/test/video_player_lifecycle_test.dart
@@ -37,21 +37,21 @@ void main() {
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-          switch (methodCall.method) {
-            case 'create':
-              return <String, dynamic>{'textureId': 1};
-            case 'play':
-              return null;
-            case 'position':
-              positionCalls += 1;
-              throw PlatformException(
-                code: 'Unknown textureId',
-                message: 'No video player associated with texture id 1',
-              );
-            default:
-              return null;
-          }
-        });
+      switch (methodCall.method) {
+        case 'create':
+          return <String, dynamic>{'textureId': 1};
+        case 'play':
+          return null;
+        case 'position':
+          positionCalls += 1;
+          throw PlatformException(
+            code: 'Unknown textureId',
+            message: 'No video player associated with texture id 1',
+          );
+        default:
+          return null;
+      }
+    });
 
     final controller = VideoPlayerController();
     await Future<void>.delayed(Duration.zero);
@@ -63,17 +63,50 @@ void main() {
     await controller.dispose();
   });
 
+  test('position polling ignores invalid absolute position values', () async {
+    var absolutePositionCalls = 0;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'create':
+          return <String, dynamic>{'textureId': 1};
+        case 'play':
+          return null;
+        case 'position':
+          return 1000;
+        case 'absolutePosition':
+          absolutePositionCalls += 1;
+          return 9223372036854775416;
+        default:
+          return null;
+      }
+    });
+
+    final controller = VideoPlayerController();
+    await Future<void>.delayed(Duration.zero);
+
+    await controller.play();
+    await Future<void>.delayed(const Duration(milliseconds: 350));
+
+    expect(absolutePositionCalls, 1);
+    expect(controller.value.position, const Duration(seconds: 1));
+    expect(controller.value.absolutePosition, isNull);
+
+    await controller.dispose();
+  });
+
   test('dispose completes when platform player creation fails', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-          if (methodCall.method == 'create') {
-            throw PlatformException(
-              code: 'create_failed',
-              message: 'Failed to create platform player',
-            );
-          }
-          return null;
-        });
+      if (methodCall.method == 'create') {
+        throw PlatformException(
+          code: 'create_failed',
+          message: 'Failed to create platform player',
+        );
+      }
+      return null;
+    });
 
     final controller = VideoPlayerController();
     await expectLater(


### PR DESCRIPTION
## Summary
- Stop the position polling timer from calling platform methods after the native player is gone
- Avoid an extra pause platform call during teardown and keep dispose safe when creation fails
- Guard Android absolutePosition against unset or out-of-range ExoPlayer window timestamps
- Return null for invalid absolute-position values before constructing Dart DateTime

## Crash fixed
Prevents fatal Dart RangeError crashes when native absolutePosition returns a near-Int64 sentinel value, for example:

```
RangeError (millisecondsSinceEpoch): Invalid value: 9223372036854775416
```

For VOD/non-live content, absolutePosition is optional metadata. Invalid values now become null while normal playback position, duration, seeking, and progress updates continue unchanged.

## Validation
- flutter test test/video_player_lifecycle_test.dart
- flutter analyze
- flutter test